### PR TITLE
fix: interview 함수 타임아웃 증가

### DIFF
--- a/src/app/ab/page.tsx
+++ b/src/app/ab/page.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function Page() {
-  return <div>ab</div>;
-}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,3 @@
+export default function HistoryPage() {
+  return <div>히스토리</div>;
+}

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function PracticePage() {
+  return <div>채팅 면접</div>;
+}

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,0 +1,3 @@
+export default function ResumePage() {
+  return <div>자소서/이력서/첨삭</div>;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "functions": {
-    "api/interview/*": {
+    "/api/interview/*": {
       "maxDuration": 50
     }
   }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/interview/*": {
+      "maxDuration": 50
+    }
+  }
+}


### PR DESCRIPTION
## 문제

- openai api 사용 시 기본으로 10초 timeout이 잡혀 생성 전 타임아웃 에러 발생
- openai api 사용하는 api 경로에 대해서만 타임아웃 50초로 설정